### PR TITLE
Removed respawn boss bars on session stop.

### DIFF
--- a/src/main/java/com/blurengine/blur/modules/spawns/respawns/StaggeredGroupRespawnsModule.kt
+++ b/src/main/java/com/blurengine/blur/modules/spawns/respawns/StaggeredGroupRespawnsModule.kt
@@ -18,7 +18,7 @@ package com.blurengine.blur.modules.spawns.respawns
 
 import com.blurengine.blur.events.players.BlurPlayerDeathEvent
 import com.blurengine.blur.events.players.BlurPlayerRespawnEvent
-import com.blurengine.blur.events.session.SessionStopEvent
+import com.blurengine.blur.events.players.PlayerSwitchSessionEvent
 import com.blurengine.blur.framework.Module
 import com.blurengine.blur.framework.ModuleData
 import com.blurengine.blur.framework.ModuleInfo
@@ -76,10 +76,12 @@ class StaggeredGroupRespawnsModule(moduleManager: ModuleManager, val data: Stagg
     }
 
     @EventHandler
-    fun onSessionStop(event: SessionStopEvent) {
-        theDead.keys.filter { it.session == event.session }.forEach {
-            spawnerBossBar.remove(it)
-            theDead.remove(it)
+    fun onPlayerSwitchSession(event: PlayerSwitchSessionEvent) {
+        if (isSession(event.oldSession)) {
+            if (data.useBossBar) {
+                theDead.remove(event.blurPlayer)
+                spawnerBossBar.remove(event.blurPlayer)
+            }
         }
     }
 

--- a/src/main/java/com/blurengine/blur/modules/spawns/respawns/StaggeredGroupRespawnsModule.kt
+++ b/src/main/java/com/blurengine/blur/modules/spawns/respawns/StaggeredGroupRespawnsModule.kt
@@ -18,6 +18,7 @@ package com.blurengine.blur.modules.spawns.respawns
 
 import com.blurengine.blur.events.players.BlurPlayerDeathEvent
 import com.blurengine.blur.events.players.BlurPlayerRespawnEvent
+import com.blurengine.blur.events.session.SessionStopEvent
 import com.blurengine.blur.framework.Module
 import com.blurengine.blur.framework.ModuleData
 import com.blurengine.blur.framework.ModuleInfo
@@ -71,6 +72,14 @@ class StaggeredGroupRespawnsModule(moduleManager: ModuleManager, val data: Stagg
         if (isSession(event)) {
             theDead.remove(event.blurPlayer)
             spawnerBossBar.remove(event.blurPlayer)
+        }
+    }
+
+    @EventHandler
+    fun onSessionStop(event: SessionStopEvent) {
+        theDead.keys.filter { it.session == event.session }.forEach {
+            spawnerBossBar.remove(it)
+            theDead.remove(it)
         }
     }
 

--- a/src/main/java/com/blurengine/blur/modules/spawns/respawns/StaggeredGroupRespawnsModule.kt
+++ b/src/main/java/com/blurengine/blur/modules/spawns/respawns/StaggeredGroupRespawnsModule.kt
@@ -18,6 +18,7 @@ package com.blurengine.blur.modules.spawns.respawns
 
 import com.blurengine.blur.events.players.BlurPlayerDeathEvent
 import com.blurengine.blur.events.players.BlurPlayerRespawnEvent
+import com.blurengine.blur.events.players.PlayerLeaveSessionEvent
 import com.blurengine.blur.events.players.PlayerSwitchSessionEvent
 import com.blurengine.blur.framework.Module
 import com.blurengine.blur.framework.ModuleData
@@ -76,8 +77,8 @@ class StaggeredGroupRespawnsModule(moduleManager: ModuleManager, val data: Stagg
     }
 
     @EventHandler
-    fun onPlayerSwitchSession(event: PlayerSwitchSessionEvent) {
-        if (isSession(event.oldSession)) {
+    fun onPlayerLeaveSession(event: PlayerLeaveSessionEvent) {
+        if (isSession(event.session)) {
             if (data.useBossBar) {
                 theDead.remove(event.blurPlayer)
                 spawnerBossBar.remove(event.blurPlayer)


### PR DESCRIPTION
This fixes an error where dead players would keep their respawn bar after matches if they were dead when the session ended (see below). This fixes the error by listening for the `SessionStopEvent`. If the event session matches the dead players session then the boss bar is removed and the player is removed from the dead list.

![](https://xorg.us/9XnjEB.png)