### PR TITLE
Fixed respawn boss bar removal (again).

### DIFF
--- a/src/main/java/com/blurengine/blur/modules/spawns/respawns/StaggeredGroupRespawnsModule.kt
+++ b/src/main/java/com/blurengine/blur/modules/spawns/respawns/StaggeredGroupRespawnsModule.kt
@@ -62,6 +62,11 @@ class StaggeredGroupRespawnsModule(moduleManager: ModuleManager, val data: Stagg
         }
     }
 
+    override fun disable() {
+        super.disable()
+        theDead.keys.forEach { destroyPlayer(it) }
+    }
+
     fun sendToDeathbox(blurPlayer: BlurPlayer) {
         theDead[blurPlayer] = System.currentTimeMillis()
         blurPlayer.coreData.isAlive = false
@@ -86,7 +91,7 @@ class StaggeredGroupRespawnsModule(moduleManager: ModuleManager, val data: Stagg
             destroyPlayer(event.blurPlayer)
         }
     }
-    
+
     private fun destroyPlayer(blurPlayer: BlurPlayer) {
         theDead.remove(blurPlayer)
         spawnerBossBar.remove(blurPlayer)


### PR DESCRIPTION
The "PlayerLeaveSessionEvent" was only called after the module was disabled so the listener was never called. This commit fixes the problem by destroying all players in the module when the module is disabled.