### PR TITLE
Modified SpawnsModule to use strategies.

### DIFF
--- a/src/main/java/com/blurengine/blur/modules/spawns/DefaultSpawnStrategy.kt
+++ b/src/main/java/com/blurengine/blur/modules/spawns/DefaultSpawnStrategy.kt
@@ -1,0 +1,12 @@
+package com.blurengine.blur.modules.spawns
+
+import org.bukkit.entity.Entity
+import java.util.function.Supplier
+
+
+class DefaultSpawnStrategy(override val spawns: Supplier<Collection<Spawn>>, val defaultSpawn: Spawn) : SpawnStrategy {
+    override fun getSpawn(entity: Entity): Spawn? {
+        val spawns = spawns.get()
+        return spawns.firstOrNull { s -> s.filter.test(entity).isAllowed } ?: defaultSpawn
+    }
+}

--- a/src/main/java/com/blurengine/blur/modules/spawns/DefaultSpawnStrategy.kt
+++ b/src/main/java/com/blurengine/blur/modules/spawns/DefaultSpawnStrategy.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Ali Moghnieh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.blurengine.blur.modules.spawns
 
 import org.bukkit.entity.Entity

--- a/src/main/java/com/blurengine/blur/modules/spawns/SpawnStrategy.kt
+++ b/src/main/java/com/blurengine/blur/modules/spawns/SpawnStrategy.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Ali Moghnieh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blurengine.blur.modules.spawns
+
+import org.bukkit.entity.Entity
+import java.util.function.Supplier
+
+/**
+ * Represents a strategical class that outputs a [Spawn] for a given [Entity].
+ * 
+ * [SpawnStrategy] are registered in [SpawnsModule] for gameplay feature.
+ */
+interface SpawnStrategy {
+    val spawns: Supplier<Collection<Spawn>>
+
+    fun getSpawn(entity: Entity): Spawn?
+}

--- a/src/main/java/com/blurengine/blur/modules/spawns/SpawnsModule.java
+++ b/src/main/java/com/blurengine/blur/modules/spawns/SpawnsModule.java
@@ -48,7 +48,11 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerRespawnEvent;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;


### PR DESCRIPTION
This change is based on how strategies are used in team assignments. The `DefaultSpawnStrategy` uses the code previously in `getNextSpawnForEntity`.