### PR TITLE
Fixed error caused by empty viewers list.

### DIFF
--- a/src/main/java/com/blurengine/blur/modules/WorldProtectModule.kt
+++ b/src/main/java/com/blurengine/blur/modules/WorldProtectModule.kt
@@ -246,7 +246,7 @@ class WorldProtectModule(moduleManager: ModuleManager, val data: WorldProtectDat
 
     @EventHandler(priority = LOWEST, ignoreCancelled = true)
     fun onPrepareItemCraft(event: PrepareItemCraftEvent) {
-        if (event.viewers.first().isCreative()) return
+        if (event.view.player.isCreative()) return
         if (event.test(data.itemCraft)) event.inventory.result = ItemStack(Material.AIR)
     }
 


### PR DESCRIPTION
The error below occurred when a player would try to put something in their inventory crafting menu. For whatever reason the `viewers` list was empty, causing the error. Accessing the `view`, instead of `viewers`, produces a player.

```
[23:11:23] [Server thread/ERROR]: Could not pass event PrepareItemCraftEvent to BlurEngine v0.2.1-SNAPSHOT-git-402f1a9
org.bukkit.event.EventException: null
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:319) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:589) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:576) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at org.bukkit.craftbukkit.v1_16_R1.event.CraftEventFactory.callPreCraftEvent(CraftEventFactory.java:1160) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.ContainerWorkbench.a(ContainerWorkbench.java:70) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.ContainerPlayer.a(ContainerPlayer.java:106) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.InventoryCrafting.setItem(InventoryCrafting.java:135) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.Slot.set(SourceFile:82) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.Container.b(Container.java:424) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.Container.a(Container.java:182) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.PlayerConnection.a(PlayerConnection.java:2199) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.PacketPlayInWindowClick.a(SourceFile:32) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.PacketPlayInWindowClick.a(SourceFile:10) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.PlayerConnectionUtils.lambda$0(PlayerConnectionUtils.java:19) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.TickTask.run(SourceFile:18) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.IAsyncTaskHandler.executeTask(SourceFile:144) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.IAsyncTaskHandler.executeNext(SourceFile:118) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.MinecraftServer.aZ(MinecraftServer.java:943) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.MinecraftServer.executeNext(MinecraftServer.java:936) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.IAsyncTaskHandler.executeAll(SourceFile:103) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.MinecraftServer.sleepForTick(MinecraftServer.java:919) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.MinecraftServer.v(MinecraftServer.java:852) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at net.minecraft.server.v1_16_R1.MinecraftServer.lambda$0(MinecraftServer.java:164) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_101]
Caused by: java.util.NoSuchElementException: List is empty.
	at kotlin.collections.CollectionsKt___CollectionsKt.first(_Collections.kt:178) ~[?:?]
	at com.blurengine.blur.modules.WorldProtectModule.onPrepareItemCraft(WorldProtectModule.kt:249) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_101]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_101]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_101]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_101]
	at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:315) ~[spigot-1.16.1.jar:git-Spigot-0509002-6b95d59]
	... 25 more
```