### PR TITLE
Additional control point getters and handling of leaving players

### DIFF
--- a/src/main/java/com/blurengine/blur/modules/controlpoints/ControlPointsModule.kt
+++ b/src/main/java/com/blurengine/blur/modules/controlpoints/ControlPointsModule.kt
@@ -292,6 +292,18 @@ class ControlPoint(val module: ControlPointsModule, private val data: ControlPoi
         return false
     }
 
+    fun getProgress(): Float {
+        return progress.progress
+    }
+
+    fun getProgressTeam(): BlurTeam? {
+        return progress.progressTeam
+    }
+
+    fun getCapturingTeam(): BlurTeam? {
+        return progress.capturingTeam
+    }
+
     private fun reevaluate() {
         // No players to capture this control point, terminate code
         if (_players.isEmpty()) {

--- a/src/main/java/com/blurengine/blur/modules/controlpoints/ControlPointsModule.kt
+++ b/src/main/java/com/blurengine/blur/modules/controlpoints/ControlPointsModule.kt
@@ -17,6 +17,7 @@
 package com.blurengine.blur.modules.controlpoints
 
 import com.blurengine.blur.Blur
+import com.blurengine.blur.events.players.PlayerLeaveSessionEvent
 import com.blurengine.blur.framework.Module
 import com.blurengine.blur.framework.ModuleData
 import com.blurengine.blur.framework.ModuleInfo
@@ -83,6 +84,17 @@ class ControlPointsModule(manager: ModuleManager, val data: ControlPointsData) :
             it.addPlayer(blurPlayer)
             playerControlPoints.put(blurPlayer, it)
             this.session.callEvent(ControlPointEnterEvent(blurPlayer, it))
+        }
+    }
+
+    @EventHandler
+    fun onPlayerLeaveSession(event: PlayerLeaveSessionEvent) {
+        if (!isSession(event)) return
+        val controlPoint = playerControlPoints[event.blurPlayer]
+        if (controlPoint != null) {
+            controlPoint.removePlayer(event.blurPlayer)
+            playerControlPoints.remove(event.blurPlayer)
+            this.session.callEvent(ControlPointExitEvent(event.blurPlayer, controlPoint))
         }
     }
 


### PR DESCRIPTION
Added three getters for control point progress parameters so that external modules can do things with them (for example progress or capture messages).

Also fixed a bug caused by a player leaving a session while in a capture point.