### PR TITLE
Fixed strategy priority sorting.

### DIFF
--- a/src/main/java/com/blurengine/blur/modules/spawns/SpawnsModule.java
+++ b/src/main/java/com/blurengine/blur/modules/spawns/SpawnsModule.java
@@ -193,7 +193,7 @@ public class SpawnsModule extends WorldModule {
         StrategyPriority foundPriority = null;
         for (SpawnStrategy spawnStrategy : this.spawnStrategies.keySet()) {
             Spawn spawn = spawnStrategy.getSpawn(entity);
-            if (spawn != null && (foundPriority == null || foundPriority.getSlot() < spawnStrategies.get(spawnStrategy).getSlot())) {
+            if (spawn != null && (foundPriority == null || spawnStrategies.get(spawnStrategy).getSlot() < foundPriority.getSlot())) {
                 foundSpawn = spawn;
                 foundPriority = spawnStrategies.get(spawnStrategy);
             }

--- a/src/main/java/com/blurengine/blur/modules/teams/TeamManager.java
+++ b/src/main/java/com/blurengine/blur/modules/teams/TeamManager.java
@@ -198,7 +198,7 @@ public class TeamManager extends Module implements SupervisorContext {
             StrategyPriority foundPriority = null;
             for (TeamAssignmentStrategy assignmentStrategy : assignmentStrategies.keySet()) {
                 BlurTeam team = assignmentStrategy.getTeam(event.getBlurPlayer());
-                if (team != null && (foundPriority == null || foundPriority.getSlot() < assignmentStrategies.get(assignmentStrategy).getSlot())) {
+                if (team != null && (foundPriority == null || assignmentStrategies.get(assignmentStrategy).getSlot() < foundPriority.getSlot())) {
                     foundTeam = team;
                     foundPriority = assignmentStrategies.get(assignmentStrategy);
                 }


### PR DESCRIPTION
The strategy priorities implemented for team and spawn selection were attempting to sort in a 'higher is better' sense, whereas they should be sorting in a 'lower is better' sense. This commit fixes the checks used.