### PR TITLE
Improved lobby countdown handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <main.package>com.blurengine.blur</main.package>
         <main.class>${main.package}.BlurPlugin</main.class>
 
-        <spigot.version>1.19.1-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.19.2-R0.1-SNAPSHOT</spigot.version>
         <commons-bukkit.version>0.9.2-SNAPSHOT</commons-bukkit.version>
         <kotlin.version>1.6.21</kotlin.version>
         <kotlin.compiler.jvmTarget>17</kotlin.compiler.jvmTarget>


### PR DESCRIPTION
This bumps the Minecraft version to 1.19.2 to keep it up to date.

I've also added customisable filters to the lobby countdown system. Previously it would just take all players online, but now modules can add their own filters for things ignored or spectating players. Implementing this also fixed a bug where players leaving the session were still included so the countdown never actually stopped.

Stopping the countdown now resets xp bars to zero xp (which is helpful for force-started sessions and not leaving stopped countdowns halfway down).