### PR TITLE
Added berries to WorldProtectModule and control point indicators.

### DIFF
--- a/src/main/java/com/blurengine/blur/modules/WorldProtectModule.kt
+++ b/src/main/java/com/blurengine/blur/modules/WorldProtectModule.kt
@@ -25,6 +25,7 @@ import com.blurengine.blur.framework.WorldModule
 import com.blurengine.blur.modules.WorldProtectModule.WorldProtectData
 import org.bukkit.GameMode
 import org.bukkit.Material
+import org.bukkit.block.data.type.CaveVinesPlant
 import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
 import org.bukkit.entity.ItemFrame
@@ -33,6 +34,7 @@ import org.bukkit.entity.Projectile
 import org.bukkit.event.Event
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority.LOWEST
+import org.bukkit.event.block.Action
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockBurnEvent
 import org.bukkit.event.block.BlockEvent
@@ -285,6 +287,14 @@ class WorldProtectModule(moduleManager: ModuleManager, val data: WorldProtectDat
         if (!event.player.isCreative() && event.test(data.playerDropItem)) event.isCancelled = true
     }
 
+    @EventHandler(priority = LOWEST, ignoreCancelled = true)
+    fun onPlayerPickBerries(event: PlayerInteractEvent) {
+        if ((event.action == Action.RIGHT_CLICK_BLOCK && event.clickedBlock!!.blockData is CaveVinesPlant) ||
+                (event.action == Action.RIGHT_CLICK_BLOCK && event.clickedBlock!!.blockData.material == Material.SWEET_BERRY_BUSH)) {
+            if (!event.player.isCreative() && event.test(data.pickBerries)) event.isCancelled = true
+        }
+    }
+
     class WorldProtectData : ModuleData {
         @Name("block-break")
         var blockBreak: Boolean = true
@@ -332,6 +342,8 @@ class WorldProtectModule(moduleManager: ModuleManager, val data: WorldProtectDat
 
         @Name("interact-block")
         var interactBlock: Boolean = false
+        @Name("pick-berries")
+        var pickBerries: Boolean = true
         @Name("item-craft")
         var itemCraft: Boolean = true
         @Name("player-bed-enter")


### PR DESCRIPTION
Added protection option for berries (both sweet berry bushes and cave vine berries).

Also added the ability to configure indicator materials for control point regions. This works by assigning an extent (`indicator` in the config) within which all blocks of material `neutral-material` get replaced by `team-materials` when the relevant teams capture the point.

Example config:
```
- Extents:
  - id: shard-point
    cylinder:
      base: 64.5, 79.0, 55.5
      radius: 5.5
      height: 3
  - id: shard-indicator
    cuboid:
      min: 25, 50, 17
      max: 94, 100, 80

- BControlPoints:
    capture-time: 5s
    control-points:
    - id: shard
      name: Shard
      capture: shard-point
      indicator: shard-indicator
      neutral-material: EMERALD_BLOCK
      team-materials:
      - id: red
        material: RED_CONCRETE
      - id: blue
        material: BLUE_CONCRETE
```